### PR TITLE
Add attribution when setting category (strategy) icons

### DIFF
--- a/site/deploy/about/about.md
+++ b/site/deploy/about/about.md
@@ -34,6 +34,23 @@ The Berkeley Center for Law and Technology supported this research in part in co
 
 This work was supported by the European Union’s Seventh Framework Programme (FP7), via the [PRIPARE project](http://pripareproject.eu/).
 
+## Attribution
+
+The following images were acquired from [thenounproject.com](https://thenounproject.com) under [Creative Commons CC BY 3.0](https://creativecommons.org/licenses/by/3.0/us/) from various users of the site, linked to original sources by the associated images below.
+
+<table>
+<tr>
+<td><a title="Shield, derivative" href="https://thenounproject.com/term/shield/304274/"><img src=https://user-images.githubusercontent.com/22982361/28218800-f2e6a78c-68b9-11e7-973e-7e88f308f6b4.png></a>
+</td><td><a title="Abstract Points, derivative" href="https://thenounproject.com/term/abstract-points/721389/"><img src=https://user-images.githubusercontent.com/22982361/28219127-25ca6098-68bb-11e7-9e5b-032eee312c81.png></a>
+</td><td><a title="Sliders, derivative" href="https://thenounproject.com/term/sliders/766889/"><img src=https://user-images.githubusercontent.com/22982361/28219130-28ea1732-68bb-11e7-9622-a200901e8128.png></a>
+</td><td><a title="Checkbox, derivative" href="https://thenounproject.com/term/checkbox/1079929/"><img src=https://user-images.githubusercontent.com/22982361/28215180-5b0a9826-68ad-11e7-941c-732b90e4cf4b.png></a>
+</td><td><a title="Webcam, derivative" href="https://thenounproject.com/term/webcam/58296/"><img src=https://user-images.githubusercontent.com/22982361/28219144-341c31d0-68bb-11e7-8a5b-f90a2125ad32.png></a>
+</td><td><a title="Original work" href=""><img src="https://user-images.githubusercontent.com/22982361/28215269-a7357446-68ad-11e7-9ca3-9dac4731bf88.png"></a>
+</td><td><a title="Diverge, derivative" href="https://thenounproject.com/term/diverge/694530/"><img src=https://cloud.githubusercontent.com/assets/22982361/23220196/739792dc-f921-11e6-84fe-90610e40bb3a.png></a>
+</td><td><a title="Information, derivative (no longer available)" href="https://thenounproject.com/jamison"><img src=https://user-images.githubusercontent.com/22982361/28219471-5dc8fc1a-68bc-11e7-8a86-17937e986f5c.png></a></td>
+</tr>
+</table>
+
 ## Contact us
 
 If you're interested in privacy patterns &mdash; because you'd like to contribute your own content, support the project in some way or suggest an improvement &mdash; please contact Nick Doty at [npdoty@ischool.berkeley.edu](mailto:npdoty@ischool.berkeley.edu).


### PR DESCRIPTION
Using even a derivative of an image calls for attribution, but we cannot attribute icons wherever they appear, as they should link to their respective categories. So, instead, attribute them in the About page.
Merge into patch-3 and not master.